### PR TITLE
Fix assign for other definitions of Result

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
   "tasks": {
-    "dev": "deno run --watch main.ts"
+    "dev": "deno run --watch src/index.ts"
   }
 }

--- a/src/Result.ts
+++ b/src/Result.ts
@@ -151,7 +151,7 @@ export class Result<E, A> {
     const state = this.state;
     switch (state.kind) {
       case 'ok': {
-        const result = other instanceof Result ? other : other(state.value);
+        const result = typeof other === 'function' ? other(state.value) : other;
         return result.map<A & { [k in K]: B }>(b => ({
           ...Object(state.value),
           [k.toString()]: b,


### PR DESCRIPTION
Same fix as https://github.com/kofno/maybeasy/pull/20 applied to `Result.assign`.